### PR TITLE
Revert to 5b7248d

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 	</div>
       </div>
     </div>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
### Why?

https://code.globality.com/ is linked from all our job specs and a lot of our
recruitment materials. The recent changes make it look pretty poor and we risk
deterring candidates. Jarrett Millette has requested that this is restored until
at least the end of the week so we can repost job adverts and update all our
documentation.

### What?

* force revert back to `5b7248d`
* restore JQuery update